### PR TITLE
Refactor download service to a single service class; add a configuration class with default logger

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,15 +75,17 @@ creative.update("campaign" => "Testing")
 
 #### Downloading Log Level Data:
 
-Downloading the log level data feed is a little different:
-
 ```ruby
-data_service = AppnexusApi::LogLevelDataService.new(connection, siphon_name: 'standard_feed')
-download_service = AppnexusApi::LogLevelDataDownloadService.new(connection, downloaded_files_path: '/local/path')
+download_service = AppnexusApi::LogLevelDataService.new(
+  connection,
+  downloaded_files_path: '/example/local/path',
+  siphon_name: 'standard_feed'
+)
 
-data_service.since(since).map { |siphon| download_service.download_resource(siphon) }.flatten
+data_service.download_new_files_since('2016-02-01'.to_time).each do |siphon|
+  download_service.download_resource(siphon)
+end
 ```
-
 
 ## Testing
 

--- a/README.md
+++ b/README.md
@@ -18,6 +18,13 @@ Or install it yourself as:
 
 ## Usage
 
+#### Configure defaults
+```ruby
+AppnexusApi.configure do |config|
+  config.logger = Logger.new('/path/to/log.log')
+end
+```
+
 #### Establish a connection:
 
 ```ruby

--- a/lib/appnexusapi.rb
+++ b/lib/appnexusapi.rb
@@ -1,7 +1,9 @@
 require 'faraday'
 require 'faraday_middleware'
+require 'logger'
 require 'retriable'
 
+require 'appnexusapi/configuration'
 require 'appnexusapi/version'
 require 'appnexusapi/error'
 require 'appnexusapi/resource'
@@ -14,4 +16,11 @@ Dir.glob("#{File.join(File.dirname(__FILE__), 'appnexusapi', 'services')}/*.rb")
 end
 
 module AppnexusApi
+  def self.config
+    @configuration ||= Configuration.new
+  end
+
+  def self.configure
+    yield(config)
+  end
 end

--- a/lib/appnexusapi/configuration.rb
+++ b/lib/appnexusapi/configuration.rb
@@ -1,0 +1,12 @@
+module AppnexusApi
+  class Configuration
+    attr_accessor :api_debug, :logger
+
+    def initialize
+      @api_debug = ENV['APPNEXUS_API_DEBUG'].to_s =~ /^(true|t|yes|y|1)$/i
+      @logger = Logger.new(STDOUT).tap do |logger|
+        @api_debug ? logger.level = Logger::DEBUG : logger.level = Logger::INFO
+      end
+    end
+  end
+end

--- a/lib/appnexusapi/connection.rb
+++ b/lib/appnexusapi/connection.rb
@@ -11,7 +11,7 @@ module AppnexusApi
         seconds = RATE_EXCEEDED_DEFAULT_TIMEOUT
       end
       seconds += RATE_EXCEEDED_DEFAULT_TIMEOUT # Just to be sure we waited long enough
-      puts "WARN: Rate limit exceeded; retrying after sleeping for #{seconds}s..."
+      AppnexusApi.config.logger.warn("WARN: Rate limit exceeded; retrying after #{seconds}s...")
       sleep(seconds)
     end
 
@@ -20,12 +20,9 @@ module AppnexusApi
     def initialize(config)
       @config = config
       @config['uri'] ||= 'https://api.appnexus.com/'
-      @api_debug = ENV['APPNEXUS_API_DEBUG'].to_s =~ /^(true|t|yes|y|1)$/i
-      @logger = @config['logger'] || Logger.new(STDOUT).tap do |logger|
-        @api_debug ? logger.level = Logger::DEBUG : logger.level = Logger::INFO
-      end
+      @logger = @config['logger'] || AppnexusApi.config.logger
       @connection = ::Faraday.new(@config['uri']) do |conn|
-        conn.response :logger, @logger, bodies: true if @api_debug
+        conn.response :logger, @logger, bodies: true if AppnexusApi.config.api_debug
         conn.request :json
         conn.response :json, :content_type => /\bjson$/
         conn.use AppnexusApi::Faraday::Response::RaiseHttpError

--- a/lib/appnexusapi/error.rb
+++ b/lib/appnexusapi/error.rb
@@ -1,5 +1,7 @@
 module AppnexusApi
   class Error < StandardError; end
+
+  class BadChecksumException < Error; end
   class BadRequest < Error; end
   class Unauthorized < Error; end
   class Forbidden < Error; end

--- a/lib/appnexusapi/faraday/raise_http_error.rb
+++ b/lib/appnexusapi/faraday/raise_http_error.rb
@@ -31,9 +31,13 @@ module AppnexusApi
           end
 
           return if response.body.empty?
+          body = JSON.parse(response.body).fetch('response', {})
 
-          if JSON.parse(response.body).fetch('response', {})['error_code'] == RATE_EXCEEDED_ERROR
+          if body['error_code'] == RATE_EXCEEDED_ERROR
             raise AppnexusApi::RateLimitExceeded, "Retry after #{response.response_headers['retry-after']}s"
+          elsif body['error_id'] && !body['error_id'].empty?
+            # TODO: this should raise an error, but a lot of the specs currently have error responses
+            # raise AppnexusApi::Error, "#{body['error_id']}: #{body['error']} - #{body['error_description']}"
           end
         end
 

--- a/lib/appnexusapi/services/log_level_data_download_service.rb
+++ b/lib/appnexusapi/services/log_level_data_download_service.rb
@@ -1,88 +1,13 @@
-class AppnexusApi::LogLevelDataDownloadService < AppnexusApi::ReadOnlyService
-  RETRY_DOWNLOAD_PARAMS = {
-    base_interval: 30,
-    tries: 20,
-    max_elapsed_time: 3600,
-    on_retry: Proc.new do |exception, tries|
-      connection.logger.warn("Retrying after #{exception.class}: #{tries} attempts.")
+require_relative './log_level_data_service'
+
+# TODO: Remove this class in v2.0
+module AppnexusApi
+  class LogLevelDataDownloadService < LogLevelDataService
+    extend Gem::Deprecate
+
+    def initialize(connection, options = {})
+      super
     end
-  }.freeze
-
-  class BadChecksumException < StandardError; end
-
-  def initialize(connection, options = {})
-    @downloaded_files_path = options[:downloaded_files_path] || '.'
-    super(connection)
-  end
-
-  # Parameter is a LogLevelDataResource FKA a "Siphon"
-  # Downloads a gzipped file
-  # Returns an array of paths to downloaded files
-  def download_resource(siphon)
-    fail 'Missing necessary information!' unless siphon.name && siphon.hour && siphon.timestamp && siphon.splits
-
-    download_params = siphon.splits.map do |split_part|
-      # In the case of files that were later replaced, there should be no checksum and they shouldn't be downloaded
-      next nil if split_part['checksum'].blank?
-
-      {
-        split_part: split_part['part'],
-        siphon_name: siphon.name,
-        timestamp: siphon.timestamp,
-        hour: siphon.hour,
-        checksum: split_part['checksum']
-      }
-    end.compact
-
-    download_params.map do |params|
-      uri = @connection.get(uri_suffix, params.reject { |k, v| k == :checksum }).headers['location']
-      filename = File.join(@downloaded_files_path, "#{params[:siphon_name]}_#{params[:hour]}_#{params[:split_part]}.gz")
-
-      Retriable.retriable(RETRY_DOWNLOAD_PARAMS) do
-        download_file(uri, filename)
-        calculated_checksum = Digest::MD5.hexdigest(File.read(filename))
-        if calculated_checksum != params[:checksum]
-          error_message = "Calculated checksum of #{calculated_checksum} doesn't match API provided checksum #{params[:checksum]}"
-          connection.logger.fatal(error_message)
-          fail(BadChecksumException, error_message)
-        end
-      end
-
-      filename
-    end
-  end
-
-  def get
-    raise AppnexusApi::NotImplemented, 'This service is designed to work via the download_resource method.'
-  end
-
-  def uri_name
-    'siphon-download'
-  end
-
-  private
-
-  def download_file(uri, filename)
-    puts "Starting HTTP download for: #{uri.to_s}..."
-    http_object = Net::HTTP.new(uri.host, uri.port)
-    http_object.use_ssl = true if uri.scheme == 'https'
-
-    begin
-      http_object.start do |http|
-        request = Net::HTTP::Get.new(uri.request_uri)
-        http.read_timeout = 500
-        http.request(request) do |response|
-          open(filename, 'wb') do |io|
-            response.read_body do |chunk|
-              io.write(chunk)
-            end
-          end
-        end
-      end
-    rescue StandardError => e
-      puts "=> Exception: '#{e}'. Skipping download."
-      return
-    end
-    puts "Stored download as #{filename}"
+    deprecate :initialize, 'LogLevelDataService#initialize', 2017, 6
   end
 end

--- a/lib/appnexusapi/services/log_level_data_service.rb
+++ b/lib/appnexusapi/services/log_level_data_service.rb
@@ -1,24 +1,105 @@
-class AppnexusApi::LogLevelDataService < AppnexusApi::ReadOnlyService
-  def initialize(connection, options = {})
-    @siphon_name = options[:siphon_name]
-    super(connection)
-  end
+module AppnexusApi
+  class LogLevelDataService < AppnexusApi::ReadOnlyService
+    RETRY_DOWNLOAD_PARAMS = {
+      base_interval: 30,
+      tries: 20,
+      max_elapsed_time: 3600,
+      on_retry: Proc.new do |exception, tries|
+        AppnexusApi.config.logger.warn("Retrying after #{exception.class}: #{tries} attempts.")
+      end
+    }.freeze
 
-  def since(time = nil)
-    params = {}
-    params[:siphon_name] = @siphon_name if @siphon_name
-    params[:updated_since] = time.strftime('%Y_%m_%d_%H') if time
-    siphons = get(params)
-
-    # Anything with the same name and hour but with a newer timestamp is a republished replacement for an older file.
-    # When this happens appnexus is supposed to set the checksum for the old file to NULL but they do not always
-    # actually do this, so we have to manually reject invalid entries.
-    siphons.reject do |siphon|
-      (siphons - [siphon]).any? { |s| s.name == siphon.name && s.hour == siphon.hour && s.timestamp > siphon.timestamp }
+    def initialize(connection, options = {})
+      @downloaded_files_path = options[:downloaded_files_path] || '.'
+      @siphon_name = options[:siphon_name] || 'standard_feed'
+      super(connection)
     end
-  end
 
-  def uri_name
-    'siphon'
+    def download_new_files_since(time = nil)
+      since(time).each { |siphon| download_resource(siphon) }
+    end
+
+    def uri_name
+      'siphon'
+    end
+
+    def uri_name
+      'siphon-download'
+    end
+
+    def since(time = nil)
+      params = {}
+      params[:siphon_name] = @siphon_name if @siphon_name
+      params[:updated_since] = time.strftime('%Y_%m_%d_%H') if time
+      siphons = get(params) || {}
+
+      # Anything with the same name and hour but with a newer timestamp is a republished replacement for an older file.
+      # When this happens appnexus is supposed to set the checksum for the old file to NULL but they do not always
+      # actually do this, so we have to manually reject invalid entries.
+      siphons.reject do |siphon|
+        (siphons - [siphon]).any? { |s| s.name == siphon.name && s.hour == siphon.hour && s.timestamp > siphon.timestamp }
+      end
+    end
+
+    private
+
+    # Parameter is a LogLevelDataResource FKA a "Siphon"
+    # Downloads a gzipped file
+    # Returns an array of paths to downloaded files
+    def download_resource(siphon)
+      fail 'Missing necessary information!' unless siphon.name && siphon.hour && siphon.timestamp && siphon.splits
+
+      download_params = siphon.splits.map do |split_part|
+        # In the case of files that were later replaced, there should be no checksum and they shouldn't be downloaded
+        next nil if split_part['checksum'].blank?
+
+        {
+          split_part: split_part['part'],
+          siphon_name: siphon.name,
+          timestamp: siphon.timestamp,
+          hour: siphon.hour,
+          checksum: split_part['checksum']
+        }
+      end.compact
+
+      download_params.map do |params|
+        uri = @connection.get(uri_suffix, params.reject { |k, v| k == :checksum }).headers['location']
+        filename = File.join(@downloaded_files_path, "#{params[:siphon_name]}_#{params[:hour]}_#{params[:split_part]}.gz")
+
+        Retriable.retriable(RETRY_DOWNLOAD_PARAMS) do
+          download_file(uri, filename)
+          calculated_checksum = Digest::MD5.hexdigest(File.read(filename))
+          if calculated_checksum != params[:checksum]
+            error_message = "Calculated checksum of #{calculated_checksum} doesn't match API provided checksum #{params[:checksum]}"
+            AppnexusApi.config.logger.fatal(error_message)
+            raise BadChecksumException, error_message
+          end
+        end
+
+        filename
+      end
+    end
+
+    def download_file(uri, filename)
+      AppnexusApi.config.logger.debug("Starting HTTP download for: #{uri.to_s}...")
+      http_object = Net::HTTP.new(uri.host, uri.port)
+      http_object.use_ssl = true if uri.scheme == 'https'
+
+      begin
+        http_object.start do |http|
+          request = Net::HTTP::Get.new(uri.request_uri)
+          http.read_timeout = 500
+          http.request(request) do |response|
+            open(filename, 'wb') do |io|
+              response.read_body do |chunk|
+                io.write(chunk)
+              end
+            end
+          end
+        end
+      end
+
+      AppnexusApi.config.logger.info("Stored download of #{uri.to_s} as #{filename}")
+    end
   end
 end

--- a/spec/fixtures/vcr/log_level_data_service_download.yml
+++ b/spec/fixtures/vcr/log_level_data_service_download.yml
@@ -23,11 +23,11 @@ http_interactions:
       Cache-Control:
       - no-store, no-cache, must-revalidate, post-check=0, pre-check=0;no-cache
       Content-Length:
-      - '698'
+      - '699'
       Content-Type:
       - application/json
       Date:
-      - Mon, 13 Feb 2017 10:00:37 GMT
+      - Mon, 13 Feb 2017 10:44:43 GMT
       Expires:
       - Thu, 19 Nov 1981 08:52:00 GMT
       Pragma:
@@ -35,19 +35,19 @@ http_interactions:
       Server:
       - Apache
       Set-Cookie:
-      - HBFAPI_SESSID=hbapi%3A171678%3A58a183c65f9a3%3Anym2; Path=/
+      - HBFAPI_SESSID=hbapi%3A171678%3A58a18e1cdbba5%3Anym2; Path=/
       X-Route:
       - "/auth"
       X-Route-Time:
-      - '1375'
+      - '1401'
     body:
       encoding: UTF-8
-      string: '{"response":{"status":"OK","token":"hbapi:171678:58a183c65f9a3:nym2","dbg_info":{"instance":"01.hbapi.test104169.nym2","slave_hit":false,"db":"master","parent_dbg_info":{"instance":"01.api.test104169.nym2","slave_hit":false,"db":"master","awesomesauce_cache_used":false,"count_cache_used":false,"uuid":"66f42891-11b1-505a-9099-ff839b2e0875","warnings":[],"time":792.37198829651,"start_microtime":1486980037.2725,"version":"1.17","output_term":"not_found"},"awesomesauce_cache_used":false,"count_cache_used":false,"uuid":"be05b49d-5dbd-5334-a9da-18e6edee3563","warnings":[],"time":1363.0979061127,"start_microtime":1486980037.247,"version":"1.17.202","slave_lag":1461580,"output_term":"not_found"}}}'
-    http_version: 
-  recorded_at: Mon, 13 Feb 2017 10:00:36 GMT
+      string: '{"response":{"status":"OK","token":"hbapi:171678:58a18e1cdbba5:nym2","dbg_info":{"instance":"01.hbapi.test104169.nym2","slave_hit":false,"db":"master","parent_dbg_info":{"instance":"01.api.test104169.nym2","slave_hit":false,"db":"master","awesomesauce_cache_used":false,"count_cache_used":false,"uuid":"fd4d53cf-d98b-551c-b92f-151974bb83a5","warnings":[],"time":805.34601211548,"start_microtime":1486982683.7509,"version":"1.17","output_term":"not_found"},"awesomesauce_cache_used":false,"count_cache_used":false,"uuid":"91321b7c-f000-5189-9b8e-33c29c07de20","warnings":[],"time":1388.9429569244,"start_microtime":1486982683.7276,"version":"1.17.202","slave_lag":1464225,"output_term":"not_found"}}}'
+    http_version:
+  recorded_at: Mon, 13 Feb 2017 10:44:43 GMT
 - request:
     method: get
-    uri: https://api-test.appnexus.com/siphon-download?num_elements=100&siphon_name=standard_feed&start_element=0&updated_since=2017_02_13_00
+    uri: https://api-test.appnexus.com/siphon?num_elements=100&siphon_name=standard_feed&start_element=0&updated_since=2017_02_13_02
     body:
       encoding: US-ASCII
       string: ''
@@ -55,7 +55,7 @@ http_interactions:
       User-Agent:
       - Faraday v0.11.0
       Authorization:
-      - hbapi:171678:58a183c65f9a3:nym2
+      - hbapi:171678:58a18e1cdbba5:nym2
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -68,11 +68,11 @@ http_interactions:
       Cache-Control:
       - no-store, no-cache, must-revalidate, post-check=0, pre-check=0;no-cache
       Content-Length:
-      - '787'
+      - '1747'
       Content-Type:
       - application/json
       Date:
-      - Mon, 13 Feb 2017 10:00:39 GMT
+      - Mon, 13 Feb 2017 10:44:45 GMT
       Expires:
       - Thu, 19 Nov 1981 08:52:00 GMT
       Pragma:
@@ -80,9 +80,68 @@ http_interactions:
       Server:
       - Apache
       Set-Cookie:
-      - HBFAPI_SESSID=hbapi%3A171678%3A58a183c65f9a3%3Anym2; Path=/
+      - HBFAPI_SESSID=hbapi%3A171678%3A58a18e1cdbba5%3Anym2; Path=/
       X-Count-Read:
-      - user:8,member:5,serviceHostUser:1,serviceHostMember:1,hostUser:5,hostMember:5,ip:0
+      - user:5,member:3,serviceHostUser:1,serviceHostMember:1,hostUser:3,hostMember:3,ip:0
+      X-Count-Write:
+      - user:0,member:0,serviceHostUser:0,serviceHostMember:0,hostUser:0,hostMember:0,ip:0
+      X-Ratelimit-Read:
+      - '1000'
+      X-Ratelimit-Service:
+      - 1000-Default
+      X-Ratelimit-System:
+      - 1000-Default
+      X-Ratelimit-Write:
+      - '1000'
+      X-Route:
+      - "/siphon"
+      X-Route-Time:
+      - '63'
+    body:
+      encoding: UTF-8
+      string: '{"response":{"status":"OK","count":7,"siphons":[{"name":"standard_feed","hour":"2017_02_13_00","timestamp":"20170213020905","splits":[{"part":"0","status":"new","checksum":"cd9006d3382e10588c2efde501f1b115"}]}],"dbg_info":{"instance":"01.hbapi.test104169.nym2","slave_hit":false,"db":"master","user::reads":5,"user::read_limit":1000,"user::read_limit_seconds":60,"user::writes":0,"user::write_limit":1000,"user::write_limit_seconds":60,"reads":3,"read_limit":1000,"read_limit_seconds":60,"writes":0,"write_limit":1000,"write_limit_seconds":60,"awesomesauce_cache_used":false,"count_cache_used":false,"uuid":"33bfe6b3-111f-543d-b500-feaac5fe4aba","warnings":[],"time":53.074836730957,"start_microtime":1486982685.5887,"version":"1.17.202","slave_miss":"no_slaves_found","slave_lag":1464225,"member_last_modified_age":498,"output_term":"not_found"}}}'
+    http_version:
+  recorded_at: Mon, 13 Feb 2017 10:44:43 GMT
+- request:
+    method: get
+    uri: https://api-test.appnexus.com/siphon-download?hour=2017_02_13_00&siphon_name=standard_feed&split_part=0&timestamp=20170213020905
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v0.11.0
+      Authorization:
+      - hbapi:171678:58a18e1cdbba5:nym2
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 302
+      message: Found
+    headers:
+      Cache-Control:
+      - no-store, no-cache, must-revalidate, post-check=0, pre-check=0
+      Content-Length:
+      - '0'
+      Content-Type:
+      - text/html; charset=UTF-8
+      Date:
+      - Mon, 13 Feb 2017 10:44:46 GMT
+      Expires:
+      - Thu, 19 Nov 1981 08:52:00 GMT
+      Location:
+      - http://data-api-client-testing-even.envnxs.com/siphon-download/p4G75fF1wAzrSMiJ01jDEvYSrsMemSmOEFRseHNI
+      Pragma:
+      - no-cache
+      Server:
+      - Apache
+      Set-Cookie:
+      - HBFAPI_SESSID=hbapi%3A171678%3A58a18e1cdbba5%3Anym2; Path=/
+      X-Count-Read:
+      - user:6,member:4,serviceHostUser:1,serviceHostMember:1,hostUser:4,hostMember:4,ip:0
       X-Count-Write:
       - user:0,member:0,serviceHostUser:0,serviceHostMember:0,hostUser:0,hostMember:0,ip:0
       X-Ratelimit-Read:
@@ -96,10 +155,59 @@ http_interactions:
       X-Route:
       - "/siphon-download"
       X-Route-Time:
-      - '22'
+      - '234'
     body:
       encoding: UTF-8
-      string: '{"response":{"error_id":"SYNTAX","error":"hour is required","error_description":null,"service":"siphon-download","method":"GET","error_code":null,"dbg_info":{"instance":"01.hbapi.test104169.nym2","slave_hit":false,"db":"master","user::reads":8,"user::read_limit":1000,"user::read_limit_seconds":60,"user::writes":0,"user::write_limit":1000,"user::write_limit_seconds":60,"reads":5,"read_limit":1000,"read_limit_seconds":60,"writes":0,"write_limit":1000,"write_limit_seconds":60,"awesomesauce_cache_used":false,"count_cache_used":false,"uuid":"15316bb9-6d1e-53cc-91a3-11de3e32fe49","warnings":[],"time":14.532089233398,"start_microtime":1486980039.1295,"version":"1.17.202","slave_miss":"no_timestamp","slave_lag":1461581,"member_last_modified_age":1486980039,"output_term":"not_found"}}}'
-    http_version: 
-  recorded_at: Mon, 13 Feb 2017 10:00:37 GMT
+      string: ''
+    http_version:
+  recorded_at: Mon, 13 Feb 2017 10:44:44 GMT
+- request:
+    method: get
+    uri: http://data-api-client-testing-even.envnxs.com/siphon-download/p4G75fF1wAzrSMiJ01jDEvYSrsMemSmOEFRseHNI
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 13 Feb 2017 10:44:46 GMT
+      Content-Disposition:
+      - filename=standard_feed_2017_02_13_00_20170213020905_0.csv.gz
+      Content-Length:
+      - '690'
+      Content-Type:
+      - application/octet-stream
+      Server:
+      - Jetty(7.6.2.v20120308)
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAAA62U224TMRCGr4en4AW8naM90zvUigtUFQlaIXGX5iAqqBI1
+        RRVvz+xmA2nSStA2UeLfXq/t+f3NMFGtwoahpGYk3oCRWkEuJG8Rj7UdU4Vi
+        IIiQE4EA4fpmBS1b7FAjYhjcylEwaMeE+ckRiUH0rxaCaq5OhhzYqpt4BVLv
+        mnbSMfPfDsLlZzi5AKoMnm9nKzW3cKx5yqjZnF+encH98v7bfDLrpssb6Lds
+        QeOTf/jL8+J4zFFommBhgQyhbdiZxVktG9QmGYg5ozCBGDO5eO9FLuAilJHn
+        eMa0s+KD78F+AKsf07FruC/wUNjTj3rLTocfbQf+hgqbK2AopfRXkf8bC2Cc
+        5dUmEyEtmlwUZcUSPNUSE5FKbY5XOAfDvAkXEoLdxfHAWPj5oLfZcHvONw2j
+        Wa4VjaMqtaq6hx7pMcnT6BmTRhvQG2UKVQ1J9CxGV3iLHoMBSdNGqq2pVm/B
+        LglMgqqR5NXO6oMuwsk7+HgOxPnqAGCCbJYp4gii7s4jgPf33c319Ha5Xi7u
+        egyP1nfL2/nRZLVaH8WXr6fnJ5/ef5CLC6iR0WK8Hp3ah1bTx2ysVa45kLlV
+        NfNEwtKNmmJwqWVecPTzM+zn0Jk274lHEDR+GZ2y5cU72srRZtI6neviquhs
+        1oqi1OI8nZYZYU043Rc668NjyUAPcfw/PhlbrtOw1uYDLOZ7fIodC/d8NnaI
+        fTwlq5zwYPwoe05REh3rkEdbVHfwVFfLzbLYeDQKDc91E0XFjli7vNbd7h86
+        pW3oVJKaxamHk4kzQTeRrb//Ws03tTEiC5i/Hny9aYfwWdM0ZISPh0nUSZ94
+        mV7QB/Uc+NLEPfEIYVJfCb6d2jiSZBmYLfL+p25ctC2yLM7Vi7erOZsSLmjI
+        LVF8MXu/AU8TTkuXBwAA
+    http_version:
+  recorded_at: Mon, 13 Feb 2017 10:44:44 GMT
 recorded_with: VCR 3.0.3

--- a/spec/fixtures/vcr/log_level_data_service_download.yml
+++ b/spec/fixtures/vcr/log_level_data_service_download.yml
@@ -1,0 +1,105 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://api-test.appnexus.com/auth
+    body:
+      encoding: UTF-8
+      string: '{"auth":{"username":"<APPNEXUS_USERNAME>","password":"<APPNEXUS_PASSWORD>"}}'
+    headers:
+      User-Agent:
+      - Faraday v0.11.0
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-store, no-cache, must-revalidate, post-check=0, pre-check=0;no-cache
+      Content-Length:
+      - '698'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 13 Feb 2017 10:00:37 GMT
+      Expires:
+      - Thu, 19 Nov 1981 08:52:00 GMT
+      Pragma:
+      - no-cache
+      Server:
+      - Apache
+      Set-Cookie:
+      - HBFAPI_SESSID=hbapi%3A171678%3A58a183c65f9a3%3Anym2; Path=/
+      X-Route:
+      - "/auth"
+      X-Route-Time:
+      - '1375'
+    body:
+      encoding: UTF-8
+      string: '{"response":{"status":"OK","token":"hbapi:171678:58a183c65f9a3:nym2","dbg_info":{"instance":"01.hbapi.test104169.nym2","slave_hit":false,"db":"master","parent_dbg_info":{"instance":"01.api.test104169.nym2","slave_hit":false,"db":"master","awesomesauce_cache_used":false,"count_cache_used":false,"uuid":"66f42891-11b1-505a-9099-ff839b2e0875","warnings":[],"time":792.37198829651,"start_microtime":1486980037.2725,"version":"1.17","output_term":"not_found"},"awesomesauce_cache_used":false,"count_cache_used":false,"uuid":"be05b49d-5dbd-5334-a9da-18e6edee3563","warnings":[],"time":1363.0979061127,"start_microtime":1486980037.247,"version":"1.17.202","slave_lag":1461580,"output_term":"not_found"}}}'
+    http_version: 
+  recorded_at: Mon, 13 Feb 2017 10:00:36 GMT
+- request:
+    method: get
+    uri: https://api-test.appnexus.com/siphon-download?num_elements=100&siphon_name=standard_feed&start_element=0&updated_since=2017_02_13_00
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v0.11.0
+      Authorization:
+      - hbapi:171678:58a183c65f9a3:nym2
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-store, no-cache, must-revalidate, post-check=0, pre-check=0;no-cache
+      Content-Length:
+      - '787'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 13 Feb 2017 10:00:39 GMT
+      Expires:
+      - Thu, 19 Nov 1981 08:52:00 GMT
+      Pragma:
+      - no-cache
+      Server:
+      - Apache
+      Set-Cookie:
+      - HBFAPI_SESSID=hbapi%3A171678%3A58a183c65f9a3%3Anym2; Path=/
+      X-Count-Read:
+      - user:8,member:5,serviceHostUser:1,serviceHostMember:1,hostUser:5,hostMember:5,ip:0
+      X-Count-Write:
+      - user:0,member:0,serviceHostUser:0,serviceHostMember:0,hostUser:0,hostMember:0,ip:0
+      X-Ratelimit-Read:
+      - '1000'
+      X-Ratelimit-Service:
+      - 1000-Default
+      X-Ratelimit-System:
+      - 1000-Default
+      X-Ratelimit-Write:
+      - '1000'
+      X-Route:
+      - "/siphon-download"
+      X-Route-Time:
+      - '22'
+    body:
+      encoding: UTF-8
+      string: '{"response":{"error_id":"SYNTAX","error":"hour is required","error_description":null,"service":"siphon-download","method":"GET","error_code":null,"dbg_info":{"instance":"01.hbapi.test104169.nym2","slave_hit":false,"db":"master","user::reads":8,"user::read_limit":1000,"user::read_limit_seconds":60,"user::writes":0,"user::write_limit":1000,"user::write_limit_seconds":60,"reads":5,"read_limit":1000,"read_limit_seconds":60,"writes":0,"write_limit":1000,"write_limit_seconds":60,"awesomesauce_cache_used":false,"count_cache_used":false,"uuid":"15316bb9-6d1e-53cc-91a3-11de3e32fe49","warnings":[],"time":14.532089233398,"start_microtime":1486980039.1295,"version":"1.17.202","slave_miss":"no_timestamp","slave_lag":1461581,"member_last_modified_age":1486980039,"output_term":"not_found"}}}'
+    http_version: 
+  recorded_at: Mon, 13 Feb 2017 10:00:37 GMT
+recorded_with: VCR 3.0.3

--- a/spec/integration/log_level_data_service_spec.rb
+++ b/spec/integration/log_level_data_service_spec.rb
@@ -1,9 +1,13 @@
 require 'spec_helper'
 
 describe AppnexusApi::LogLevelDataService do
+  after(:each) do
+    system('rm standard_feed_2017_02_13_00_0.gz')
+  end
+
   it 'downloads new files' do
     VCR.use_cassette('log_level_data_service_download') do
-      described_class.new(connection).download_new_files_since(Time.now - 7200)
+      described_class.new(connection).download_new_files_since(Time.new(2017, 2, 13, 2, 2, 2))
     end
   end
 end

--- a/spec/integration/log_level_data_service_spec.rb
+++ b/spec/integration/log_level_data_service_spec.rb
@@ -1,0 +1,9 @@
+require 'spec_helper'
+
+describe AppnexusApi::LogLevelDataService do
+  it 'downloads new files' do
+    VCR.use_cassette('log_level_data_service_download') do
+      described_class.new(connection).download_new_files_since(Time.now - 7200)
+    end
+  end
+end

--- a/spec/integration/placement_spec.rb
+++ b/spec/integration/placement_spec.rb
@@ -1,7 +1,6 @@
 require 'spec_helper'
 
 describe AppnexusApi::PlacementService do
-
   include_context 'with a publisher'
 
   let(:placement_service) { described_class.new(connection) }


### PR DESCRIPTION
There only needs to be one download service.

The default logger fixes an annoyance whereby the retry `Proc` did not have access to the `connection.logger`.